### PR TITLE
Add Jupyter Notebook for integrating math dataset with VishwamAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ tokenizer.subject_specific_tokens.update({
 })
 ```
 
+### Using the Jupyter Notebook for Math Dataset Integration
+
+A new Jupyter Notebook file `math/vishwamai_math_integration.ipynb` has been added to demonstrate how to integrate a small math dataset with VishwamAI. The notebook includes sections for loading the dataset, initializing the model, training the model, and evaluating the results.
+
+To use the notebook, follow these steps:
+
+1. Open the Jupyter Notebook:
+   ```bash
+   jupyter notebook math/vishwamai_math_integration.ipynb
+   ```
+
+2. Follow the instructions in the notebook to load the dataset, initialize the model, train the model, and evaluate the results.
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for more details.

--- a/math/vishwamai_math_integration.ipynb
+++ b/math/vishwamai_math_integration.ipynb
@@ -1,0 +1,193 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Integrating a Small Math Dataset with VishwamAI\n",
+    "\n",
+    "This notebook demonstrates how to integrate a small math dataset with VishwamAI. We will go through the following steps:\n",
+    "1. Loading the dataset\n",
+    "2. Initializing the model\n",
+    "3. Training the model\n",
+    "4. Evaluating the results\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Loading the Dataset\n",
+    "\n",
+    "We will use the DeepMind Mathematics dataset for this example. Let's start by loading the dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import datasets\n",
+    "from datasets import load_dataset\n",
+    "\n",
+    "# Load the dataset\n",
+    "train_examples, val_examples = load_dataset(\n",
+    "    'math_dataset/arithmetic__mul',\n",
+    "    split=['train', 'test'],\n",
+    "    as_supervised=True\n",
+    ")\n",
+    "\n",
+    "print(f\"Loaded {len(train_examples)} training examples and {len(val_examples)} validation examples.\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Initializing the Model\n",
+    "\n",
+    "Next, we will initialize the VishwamAI model. We will use the `train_math_model` function from `train_math.py` to set up the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from vishwamai.architecture import init_model, VishwamaiConfig\n",
+    "from vishwamai.conceptual_tokenizer import ConceptualTokenizer, ConceptualTokenizerConfig\n",
+    "from vishwamai.training import VishwamaiTrainer\n",
+    "from torch.utils.data import DataLoader\n",
+    "\n",
+    "# Define the model configuration\n",
+    "config = {\n",
+    "    'model_config': {\n",
+    "        'dim': 256,\n",
+    "        'n_layers': 6,\n",
+    "        'n_heads': 8,\n",
+    "        'vocab_size': 1000,\n",
+    "        'max_seq_len': 512\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "# Initialize model configuration\n",
+    "model_config = VishwamaiConfig(**config['model_config'])\n",
+    "model = init_model(model_config)\n",
+    "\n",
+    "# Initialize tokenizer\n",
+    "tokenizer_config = ConceptualTokenizerConfig(\n",
+    "    vocab_size=config['model_config'].get('vocab_size', 32000),\n",
+    "    max_length=config['model_config'].get('max_length', 512),\n",
+    "    concept_tokens=[\"math\", \"logic\", \"science\"],\n",
+    "    reasoning_tokens=[\"if\", \"then\", \"equals\", \"because\"]\n",
+    ")\n",
+    "tokenizer = ConceptualTokenizer(tokenizer_config)\n",
+    "\n",
+    "print(\"Model and tokenizer initialized.\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Training the Model\n",
+    "\n",
+    "We will now train the model using the `train_math_model` function from `train_math.py`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def train_math_model(train_dataset, val_dataset, config):\n",
+    "    # Initialize model configuration\n",
+    "    model_config = VishwamaiConfig(**config['model_config'])\n",
+    "    model = init_model(model_config)\n",
+    "    tokenizer_config = ConceptualTokenizerConfig(\n",
+    "        vocab_size=config['model_config'].get('vocab_size', 32000),\n",
+    "        max_length=config['model_config'].get('max_length', 512),\n",
+    "        concept_tokens=[\"math\", \"logic\", \"science\"],\n",
+    "        reasoning_tokens=[\"if\", \"then\", \"equals\", \"because\"]\n",
+    "    )\n",
+    "    tokenizer = ConceptualTokenizer(tokenizer_config)\n",
+    "    \n",
+    "    train_loader = DataLoader(train_dataset, batch_size=32, shuffle=True)\n",
+    "    val_loader = DataLoader(val_dataset, batch_size=32, shuffle=False)\n",
+    "    \n",
+    "    trainer = VishwamaiTrainer(\n",
+    "        model=model,\n",
+    "        tokenizer=tokenizer,\n",
+    "        train_dataset=train_loader,\n",
+    "        eval_dataset=val_loader,\n",
+    "        device=\"cuda\"\n",
+    "    )\n",
+    "    \n",
+    "    trainer.train(\n",
+    "        num_epochs=10,\n",
+    "        save_dir=\"./models\",\n",
+    "        evaluation_steps=100,\n",
+    "        save_steps=1000,\n",
+    "        logging_steps=10\n",
+    "    )\n",
+    "\n",
+    "# Train the model\n",
+    "train_math_model(train_examples, val_examples, config)\n",
+    "\n",
+    "print(\"Model training completed.\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Evaluating the Results\n",
+    "\n",
+    "Finally, we will evaluate the trained model on the validation dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Evaluate the model\n",
+    "trainer = VishwamaiTrainer(\n",
+    "    model=model,\n",
+    "    tokenizer=tokenizer,\n",
+    "    train_dataset=train_loader,\n",
+    "    eval_dataset=val_loader,\n",
+    "    device=\"cuda\"\n",
+    ")\n",
+    "\n",
+    "eval_results = trainer.evaluate()\n",
+    "print(f\"Evaluation results: {eval_results}\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Add a new Jupyter Notebook for integrating a small math dataset with VishwamAI.

* **New Jupyter Notebook**: Add `math/vishwamai_math_integration.ipynb` to demonstrate how to integrate a small math dataset with VishwamAI. Include sections for loading the dataset, initializing the model, training the model, and evaluating the results.
* **README Update**: Update `README.md` to include instructions on how to use the new Jupyter Notebook for training models on the math dataset.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/VishwamAI/VishwamAI/pull/7?shareId=c83be9df-9003-41fa-9570-883975b1886b).