### PR TITLE
Update experiment2 to save model as .safetensors

### DIFF
--- a/notebooks/experiment2.ipynb
+++ b/notebooks/experiment2.ipynb
@@ -40,6 +40,7 @@
     "    DuckDBLogger,\n",
     "    DEFAULT_CONFIG\n",
     ")\n",
+    "from safetensors.flax import save_file\n",
     "\n",
     "# Check TPU configuration\n",
     "print(\"JAX devices:\", jax.devices())\n",
@@ -75,7 +76,8 @@
     "    'use_rotary': True,\n",
     "    'use_rms_norm': True,\n",
     "    'dtype': 'bfloat16',\n",
-    "    'compute_dtype': 'float32'\n",
+    "    'compute_dtype': 'float32',\n",
+    "    'save_format': 'safetensors'\n",
     "})\n",
     "\n",
     "# Update training configuration\n",
@@ -499,6 +501,10 @@
     "# Save configuration\n",
     "with open(f\"{save_dir}/config.json\", 'w') as f:\n",
     "    json.dump(config, f, indent=2)\n",
+    "\n",
+    "# Save model as .safetensors\n",
+    "params = jax.device_get(trainer.pipeline.state.params)\n",
+    "save_file(params, f\"{save_dir}/model.safetensors\")\n",
     "\n",
     "print(f\"Model and configuration saved to {save_dir}\")"
    ]

--- a/train_distill.py
+++ b/train_distill.py
@@ -9,6 +9,7 @@ import jax
 from typing import Any, Dict
 from vishwamai.training import create_trainer
 from vishwamai.transformer import create_vishwamai_transformer
+from safetensors.flax import save_file
 
 def load_config(config_path: str) -> Dict[str, Any]:
     """Load model configuration from JSON file."""
@@ -65,9 +66,16 @@ def main():
     # Run training
     trainer.train()
     
+    # Save model as .safetensors
+    save_dir = 'final_model'
+    os.makedirs(save_dir, exist_ok=True)
+    params = jax.device_get(trainer.pipeline.state.params)
+    save_file(params, f"{save_dir}/model.safetensors")
+    
     print("Training completed!")
     print("Final logs exported to 'logs' directory")
     print(f"Database available at: training_logs.db")
+    print(f"Model saved as .safetensors in {save_dir}")
 
 if __name__ == "__main__":
     main()

--- a/vishwamai/__init__.py
+++ b/vishwamai/__init__.py
@@ -2,6 +2,8 @@
 VishwamAI Transformer Implementation
 """
 
+import safetensors  # Import safetensors library
+
 # Core Model Components
 from .transformer import (
     create_vishwamai_transformer,
@@ -120,5 +122,8 @@ __all__ = [
     'DuckDBLogger',
     
     # Configuration
-    'DEFAULT_CONFIG'
+    'DEFAULT_CONFIG',
+    
+    # Model Saving
+    'safetensors'
 ]


### PR DESCRIPTION
Update VishwamAI model to save as .safetensors according to Vishwamai colab tpu v2 model.

* **notebooks/experiment2.ipynb**
  - Import `save_file` from `safetensors.flax`.
  - Update model configuration to include `save_format` as 'safetensors'.
  - Add code to save the trained model as .safetensors at the end of the training loop.

* **vishwamai/__init__.py**
  - Import `safetensors` library.
  - Add `safetensors` to the `__all__` list.

* **train_distill.py**
  - Import `save_file` from `safetensors.flax`.
  - Add code to save the trained model as .safetensors at the end of the training loop.
  - Print message indicating the model is saved as .safetensors.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/VishwamAI/VishwamAI?shareId=XXXX-XXXX-XXXX-XXXX).